### PR TITLE
Remove API Key from Google Books

### DIFF
--- a/Jellyfin.Plugin.Bookshelf/Jellyfin.Plugin.Bookshelf.csproj
+++ b/Jellyfin.Plugin.Bookshelf/Jellyfin.Plugin.Bookshelf.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <RootNamespace>Jellyfin.Plugin.Bookshelf</RootNamespace>
-    <AssemblyVersion>1.0.0</AssemblyVersion>
-    <FileVersion>1.0.0</FileVersion>
+    <AssemblyVersion>2.0.0</AssemblyVersion>
+    <FileVersion>2.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.Bookshelf/Providers/GoogleBooks/ApiUrls.cs
+++ b/Jellyfin.Plugin.Bookshelf/Providers/GoogleBooks/ApiUrls.cs
@@ -4,7 +4,7 @@
     {
         private const string ApiKey = "AIzaSyCFqC6-BAZwqvOBnbNYN8fbK-R1swtnDac";
         // GoogleBooks API Endpoints
-        public const string SearchUrl = @"https://www.googleapis.com/books/v1/volumes?q={0}&startIndex={1}&maxResults={2}&key=" + ApiKey;
-        public const string DetailsUrl = @"https://www.googleapis.com/books/v1/volumes/{0}?key=" + ApiKey;
+        public const string SearchUrl = @"https://www.googleapis.com/books/v1/volumes?q={0}&startIndex={1}&maxResults={2}";
+        public const string DetailsUrl = @"https://www.googleapis.com/books/v1/volumes/{0}";
     }
 }

--- a/Jellyfin.Plugin.Bookshelf/Providers/GoogleBooks/ApiUrls.cs
+++ b/Jellyfin.Plugin.Bookshelf/Providers/GoogleBooks/ApiUrls.cs
@@ -2,7 +2,6 @@
 {
     public static class GoogleApiUrls
     {
-        private const string ApiKey = "AIzaSyCFqC6-BAZwqvOBnbNYN8fbK-R1swtnDac";
         // GoogleBooks API Endpoints
         public const string SearchUrl = @"https://www.googleapis.com/books/v1/volumes?q={0}&startIndex={1}&maxResults={2}";
         public const string DetailsUrl = @"https://www.googleapis.com/books/v1/volumes/{0}";

--- a/build.yaml
+++ b/build.yaml
@@ -1,7 +1,7 @@
 ---
 name: "jellyfin-plugin-bookshelf"
 guid: "9c4e63f1-031b-4f25-988b-4f7d78a8b53e"
-version: "1" # Please increment with each pull request
+version: "2" # Please increment with each pull request
 jellyfin_version: "10.3.0" # The earliest binary-compatible version
 owner: "jellyfin"
 nicename: "Bookshelf"


### PR DESCRIPTION
As per the Google docs, API Keys aren’t needed when searching for volumes or retrieving details. This PR removes that entirely.

Fixes #4.

Reference: https://developers.google.com/books/docs/v1/using