### PR TITLE
Update supported metadata providers and file types

### DIFF
--- a/Jellyfin.Plugin.Bookshelf/Configuration/configPage.html
+++ b/Jellyfin.Plugin.Bookshelf/Configuration/configPage.html
@@ -11,25 +11,36 @@
             <div class="content-primary">
                 <h1>Bookshelf</h1>
                 <p>To set up Bookshelf, just add a media library in the server configuration and set the content type to
-                    books. This plugin supports standard OPF as well as Calibre OPF if you'd like to import the metadata
-                    from another program. If you want to see support for a specific provider we always welcome code
+                    books. If you want to see support for a specific provider we always welcome code
                     contributions!
                 </p>
                 <h1>Supported Formats</h1>
+                Please take in mind that his is not a complete list.
                 <ul>
                     <li>epub</li>
                     <li>mobi</li>
                     <li>pdf</li>
                     <li>cbz</li>
                     <li>cbr</li>
+                    <li>mp3</li>
+                    <li>m4a</li>
+                    <li>m4b</li>
+                    <li>flac</li>
                 </ul>
 
+                <h1>Offline Metadata providers</h1>
+                <ul>
+                    <li>Open Packaging Format (OPF)</li>
+                    <li>Calibre OPF</li>
+                    <li>ComicInfo</li>
+                    <li>ComicBookInfo</li>
+                </ul>
                 The following <b>limitations</b> apply:
                 <ul>
                     <li>
                         .cbr Comics tagged with ComicRack's ComicInfo format
                         are partially supported. Any metadata bundled with the
-                        comic book itself will be ignored.
+                        comic book itself will be ignored. External files will be read.
                     </li>
                     <li>
                         The
@@ -41,6 +52,11 @@
                         <a href="https://www.denvog.com/comet/comet-specification/">CoMet</a>
                         format is not supported.
                     </li>
+                </ul>
+
+                <h1>Online Metadata providers</h1>
+                <ul>
+                    <li>Google Books</li>
                 </ul>
             </div>
         </div>

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@
 
 ## About
 
-The Jellyfin Bookshelf plugin enables the collection of eBooks & AudioBooks, with the latter being able to be played through Jellyfin. This plugin uses Google Books as a Metadata provider.
+The Jellyfin Bookshelf plugin enables the collection of eBooks & AudioBooks, with the latter being able to be played through Jellyfin.
 
-Supported eBook file types:
+### Supported eBook file types:
 
 - epub
 - mobi
@@ -29,10 +29,34 @@ Supported eBook file types:
 - cbz
 - cbr
 
+### Supported audio book file types:
+
+Please take in mind that his is not a complete list and represents some of the most commonly used formats.
+
+- mp3
+- m4a
+- m4b
+- flac
+
+### Offline Metadata providers:
+
+This plugin supports the following offline Metadata providers. These will check the local files for metadata.
+
+- [Open Packaging Format (OPF)](http://idpf.org/epub/20/spec/OPF_2.0.1_draft.htm)
+- Calibre OPF
+- [ComicInfo](https://github.com/anansi-project/comicinfo)
+- [ComicBookInfo](https://code.google.com/archive/p/comicbookinfo/)
+
 The following **limitations** apply:
 - .cbr Comics tagged with ComicRacks ComicInfo format are partially supported. Any metadata within the comic book itself will be ignored while external metadata within a ComicInfo.xml file can be read.
 - The _[Advanced Comic Book Format](https://launchpad.net/acbf)_ is not supported.
-- The _[ComicBookInfo](https://code.google.com/archive/p/comicbookinfo/)_ format is not supported. (Not to be confused with the ComicInfo.xml format from ComicRack)
+- The _[CoMet](https://www.denvog.com/comet/comet-specification/)_ format is not supported.
+
+### Online Metadata providers:
+
+These Metadata providers will check online services for metadata.
+
+- Google Books
 
 
 ## Build & Installation Process


### PR DESCRIPTION
I noticed that both the `README` and the `configPage` specify which metadata providers and file types are being supported. However, the list of supported metadata providers is not complete and only file types for eBooks are being mentioned while the `README` clearly states that this plugin supports both eBooks & AudioBooks.

This PR updates both files to resolve the aforementioned shortcomings.