### PR TITLE
Add development setup for Visual Studio Code

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,11 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=827846 to learn about workspace recommendations.
+    // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
+    // List of extensions which should be recommended for users of this workspace.
+    "recommendations": [
+        "ms-dotnettools.csharp",
+        "editorconfig.editorconfig"
+    ],
+    // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
+    "unwantedRecommendations": []
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,28 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": ".NET Core Launch (console)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build-and-copy",
+            "program": "${config:jellyfinDir}/bin/Debug/net6.0/jellyfin.dll",
+            "args": [
+                //"--nowebclient"
+                "--webdir",
+                "${config:jellyfinWebDir}/dist/"
+            ],
+            "cwd": "${config:jellyfinDir}",
+            "console": "internalConsole",
+            "stopAtEntry": false,
+            "internalConsoleOptions": "openOnSessionStart",
+            "serverReadyAction": {
+                "action": "openExternally",
+                "pattern": "Overriding address\\(es\\) \\'(https?:\\S+)\\'",
+            },
+        }
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,19 @@
+{
+    // jellyfinDir : The directory of the cloned jellyfin server project
+    // This needs to be built once before it can be used
+    "jellyfinDir": "${workspaceFolder}/../jellyfin/Jellyfin.Server",
+    // jellyfinWebDir : The directory of the cloned jellyfin-web project
+    // This needs to be built once before it can be used
+    "jellyfinWebDir": "${workspaceFolder}/../jellyfin-web",
+    // jellyfinDataDir : the root data directory for a running jellyfin instance
+    // This is where jellyfin stores its configs, plugins, metadata etc
+    // This is platform specific by default, but on Windows defaults to
+    // ${env:LOCALAPPDATA}/jellyfin
+    // and on Linux, it defaults to
+    // ${env:XDG_DATA_HOME}/jellyfin
+    // However ${env:XDG_DATA_HOME} does not work in Visual Studio Code's development container!
+    "jellyfinWindowsDataDir": "${env:LOCALAPPDATA}/jellyfin",
+    "jellyfinLinuxDataDir": "$HOME/.local/share/jellyfin",
+    // The name of the plugin
+    "pluginName": "Jellyfin.Plugin.Bookshelf",
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,68 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "build-and-copy",
+            "dependsOrder": "sequence",
+            "dependsOn": [
+                "build",
+                "make-plugin-dir",
+                "copy-dll",
+            ],
+        },
+        {
+            "label": "build",
+            "command": "dotnet",
+            "type": "shell",
+            "args": [
+                "publish",
+                "${workspaceFolder}/${config:pluginName}.sln",
+                "/property:GenerateFullPaths=true",
+                "/consoleloggerparameters:NoSummary"
+            ],
+            "group": "build",
+            "presentation": {
+                "reveal": "silent"
+            },
+            "problemMatcher": "$msCompile"
+        },
+        {
+            "label": "make-plugin-dir",
+            "type": "shell",
+            "command": "mkdir",
+            "windows": {
+                "args": [
+                    "-Force",
+                    "-Path",
+                    "${config:jellyfinWindowsDataDir}/plugins/${config:pluginName}/"
+                ]
+            },
+            "linux": {
+                "args": [
+                    "-p",
+                    "${config:jellyfinLinuxDataDir}/plugins/${config:pluginName}/"
+                ]
+            }
+        },
+        {
+            "label": "copy-dll",
+            "type": "shell",
+            "command": "cp",
+            "windows": {
+                "args": [
+                    "./${config:pluginName}/bin/Debug/net6.0/publish/*",
+                    "${config:jellyfinWindowsDataDir}/plugins/${config:pluginName}/"
+                ]
+            },
+            "linux": {
+                "args": [
+                    "-r",
+                    "./${config:pluginName}/bin/Debug/net6.0/publish/*",
+                    "${config:jellyfinLinuxDataDir}/plugins/${config:pluginName}/"
+                ]
+            }
+        }
+    ]
+}


### PR DESCRIPTION
The implementation of the development setup is **based upon** the implementation in the _plugin template repository_ with addition of proper linux support.  While it's not an optimal solution, I copied the _jellyfinWindowsDataDir_ to have a _jellyfinLinuxDataDir_. It seems like it's not possible to add platform specific data to the _.vscode/settings.json_ unless every user installs additional extensions.

I also added the required plugins to the `.vscode/extensions.json` file.

**Note:** I tested this setup under Linux only (as I currently don't have access to a Windows machine), thought it should work under Windows as I made no changes to the Windows part of the development setup.

**Supported platforms by this PR:**
- Linux
- Windows