### PR TITLE
Update EpubMetadataImageProvider.cs

### DIFF
--- a/Jellyfin.Plugin.Bookshelf/Providers/Epub/EpubMetadataImageProvider.cs
+++ b/Jellyfin.Plugin.Bookshelf/Providers/Epub/EpubMetadataImageProvider.cs
@@ -91,26 +91,26 @@ namespace Jellyfin.Plugin.Bookshelf.Providers.Epub
             return response;
         }
 
-        private Task<DynamicImageResponse> GetFromZip(BaseItem item)
+        private async Task<DynamicImageResponse> GetFromZip(BaseItem item)
         {
             using var epub = ZipFile.OpenRead(item.Path);
 
             var opfFilePath = EpubUtils.ReadContentFilePath(epub);
             if (opfFilePath == null)
             {
-                return Task.FromResult(new DynamicImageResponse { HasImage = false });
+                return new DynamicImageResponse { HasImage = false };
             }
 
             var opfRootDirectory = Path.GetDirectoryName(opfFilePath);
             if (string.IsNullOrEmpty(opfRootDirectory))
             {
-                return Task.FromResult(new DynamicImageResponse { HasImage = false });
+                return new DynamicImageResponse { HasImage = false };
             }
 
             var opfFile = epub.GetEntry(opfFilePath);
             if (opfFile == null)
             {
-                return Task.FromResult(new DynamicImageResponse { HasImage = false });
+                return new DynamicImageResponse { HasImage = false };
             }
 
             using var opfStream = opfFile.Open();
@@ -118,7 +118,7 @@ namespace Jellyfin.Plugin.Bookshelf.Providers.Epub
             var opfDocument = new XmlDocument();
             opfDocument.Load(opfStream);
 
-            return LoadCover(epub, opfDocument, opfRootDirectory);
+            return await LoadCover(epub, opfDocument, opfRootDirectory).ConfigureAwait(false);
         }
     }
 }


### PR DESCRIPTION
On my machine, scanning Epub gives read cover error
```
[09:58:02] [ERR] [35] MediaBrowser.Providers.Books.BookMetadataService: Error in Epub Metadata
System.NotSupportedException: This stream from ZipArchiveEntry does not support reading
```
I'm not sure if anyone else has this problem, the suspicion is that the epub object is Dispose
this pr solved my problem