### PR TITLE
Add Unit tests for ComicInfo and ComicBookInfo formats

### DIFF
--- a/Jellyfin.Plugin.Bookshelf.sln
+++ b/Jellyfin.Plugin.Bookshelf.sln
@@ -3,6 +3,10 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jellyfin.Plugin.Bookshelf", "Jellyfin.Plugin.Bookshelf\Jellyfin.Plugin.Bookshelf.csproj", "{8D744D83-5403-4BA4-8794-760AF69DAC06}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{6215AFB5-402D-4B86-BD96-E33FC37B44EF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Jellyfin.Plugin.Bookshelf.Tests", "tests\Jellyfin.Plugin.Bookshelf.Tests\Jellyfin.Plugin.Bookshelf.Tests.csproj", "{FC333648-2AEE-4759-9088-35386909CB58}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -13,5 +17,12 @@ Global
 		{8D744D83-5403-4BA4-8794-760AF69DAC06}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8D744D83-5403-4BA4-8794-760AF69DAC06}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8D744D83-5403-4BA4-8794-760AF69DAC06}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FC333648-2AEE-4759-9088-35386909CB58}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FC333648-2AEE-4759-9088-35386909CB58}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FC333648-2AEE-4759-9088-35386909CB58}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FC333648-2AEE-4759-9088-35386909CB58}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{FC333648-2AEE-4759-9088-35386909CB58} = {6215AFB5-402D-4B86-BD96-E33FC37B44EF}
 	EndGlobalSection
 EndGlobal

--- a/Jellyfin.Plugin.Bookshelf/Providers/ComicBookInfo/ComicBookInfoProvider.cs
+++ b/Jellyfin.Plugin.Bookshelf/Providers/ComicBookInfo/ComicBookInfoProvider.cs
@@ -195,7 +195,7 @@ namespace Jellyfin.Plugin.Bookshelf.Providers.ComicBookInfo
         {
             try
             {
-                return new CultureInfo(language).DisplayName;
+                return CultureInfo.GetCultureInfo(language).DisplayName;
             }
             catch (Exception)
             {

--- a/Jellyfin.Plugin.Bookshelf/Providers/ComicBookInfo/ComicBookInfoProvider.cs
+++ b/Jellyfin.Plugin.Bookshelf/Providers/ComicBookInfo/ComicBookInfoProvider.cs
@@ -2,7 +2,6 @@ using System;
 using System.Globalization;
 using System.IO;
 using System.Linq;
-using System.Text;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -18,7 +17,7 @@ namespace Jellyfin.Plugin.Bookshelf.Providers.ComicBookInfo
     /// <summary>
     /// Comic book info provider.
     /// </summary>
-    public class ComicBookInfoProvider : IComicFileProvider
+    public class ComicBookInfoProvider : IComicFileProvider, IComicBookInfoUtilities
     {
         private readonly ILogger<ComicBookInfoProvider> _logger;
 
@@ -118,22 +117,14 @@ namespace Jellyfin.Plugin.Bookshelf.Providers.ComicBookInfo
 
             if (comic.Metadata.Credits.Count > 0)
             {
-                foreach (var person in comic.Metadata.Credits)
-                {
-                    if (person.Person is null || person.Role is null)
-                    {
-                        continue;
-                    }
-
-                    var personInfo = new PersonInfo { Name = person.Person, Type = person.Role };
-                    metadataResult.AddPerson(personInfo);
-                }
+                ReadPeopleMetadata(comic.Metadata, metadataResult);
             }
 
             return metadataResult;
         }
 
-        private Book? ReadComicBookMetadata(ComicBookInfoMetadata comic)
+        /// <inheritdoc />
+        public Book? ReadComicBookMetadata(ComicBookInfoMetadata comic)
         {
             var book = new Book();
             var hasFoundMetadata = false;
@@ -178,6 +169,35 @@ namespace Jellyfin.Plugin.Bookshelf.Providers.ComicBookInfo
             }
         }
 
+        /// <inheritdoc />
+        public void ReadPeopleMetadata(ComicBookInfoMetadata comic, MetadataResult<Book> metadataResult)
+        {
+            foreach (var person in comic.Credits)
+            {
+                if (person.Person is null || person.Role is null)
+                {
+                    continue;
+                }
+
+                var personInfo = new PersonInfo { Name = person.Person, Type = person.Role };
+                metadataResult.AddPerson(personInfo);
+            }
+        }
+
+        /// <inheritdoc />
+        public string? ReadCultureInfoAsThreeLetterIsoInto(string language)
+        {
+            try
+            {
+                return new CultureInfo(language).ThreeLetterISOLanguageName;
+            }
+            catch (Exception)
+            {
+                // Ignored
+                return null;
+            }
+        }
+
         private bool ReadStringInto(string? data, Action<string> commitResult)
         {
             if (!string.IsNullOrWhiteSpace(data))
@@ -201,19 +221,6 @@ namespace Jellyfin.Plugin.Bookshelf.Providers.ComicBookInfo
             catch (Exception)
             {
                 // Nothing to do here
-                return null;
-            }
-        }
-
-        private string? ReadCultureInfoAsThreeLetterIsoInto(string language)
-        {
-            try
-            {
-                return new CultureInfo(language).ThreeLetterISOLanguageName;
-            }
-            catch (Exception)
-            {
-                // Ignored
                 return null;
             }
         }

--- a/Jellyfin.Plugin.Bookshelf/Providers/ComicBookInfo/ComicBookInfoProvider.cs
+++ b/Jellyfin.Plugin.Bookshelf/Providers/ComicBookInfo/ComicBookInfoProvider.cs
@@ -112,7 +112,7 @@ namespace Jellyfin.Plugin.Bookshelf.Providers.ComicBookInfo
 
             if (comic.Metadata.Language is not null)
             {
-                metadataResult.ResultLanguage = ReadCultureInfoAsThreeLetterIsoInto(comic.Metadata.Language);
+                metadataResult.ResultLanguage = ReadCultureInfoInto(comic.Metadata.Language);
             }
 
             if (comic.Metadata.Credits.Count > 0)
@@ -191,11 +191,11 @@ namespace Jellyfin.Plugin.Bookshelf.Providers.ComicBookInfo
         }
 
         /// <inheritdoc />
-        public string? ReadCultureInfoAsThreeLetterIsoInto(string language)
+        public string? ReadCultureInfoInto(string language)
         {
             try
             {
-                return new CultureInfo(language).ThreeLetterISOLanguageName;
+                return new CultureInfo(language).DisplayName;
             }
             catch (Exception)
             {

--- a/Jellyfin.Plugin.Bookshelf/Providers/ComicBookInfo/ComicBookInfoProvider.cs
+++ b/Jellyfin.Plugin.Bookshelf/Providers/ComicBookInfo/ComicBookInfoProvider.cs
@@ -179,6 +179,12 @@ namespace Jellyfin.Plugin.Bookshelf.Providers.ComicBookInfo
                     continue;
                 }
 
+                if (person.Person.Contains(',', StringComparison.InvariantCultureIgnoreCase))
+                {
+                    var name = person.Person.Split(',');
+                    person.Person = name[1].Trim(' ') + " " + name[0].Trim(' ');
+                }
+
                 var personInfo = new PersonInfo { Name = person.Person, Type = person.Role };
                 metadataResult.AddPerson(personInfo);
             }

--- a/Jellyfin.Plugin.Bookshelf/Providers/ComicBookInfo/IComicBookInfoUtilities.cs
+++ b/Jellyfin.Plugin.Bookshelf/Providers/ComicBookInfo/IComicBookInfoUtilities.cs
@@ -23,10 +23,10 @@ namespace Jellyfin.Plugin.Bookshelf.Providers.ComicBookInfo
         void ReadPeopleMetadata(ComicBookInfoMetadata comic, MetadataResult<Book> metadataResult);
 
         /// <summary>
-        /// Converts a language to the three letter iso name of the language.
+        /// Returns the language display name of a given language.
         /// </summary>
         /// <param name="language">The language to convert.</param>
-        /// <returns>The language represented by an three letter iso name.</returns>
-        string? ReadCultureInfoAsThreeLetterIsoInto(string language);
+        /// <returns>The language display name.</returns>
+        string? ReadCultureInfoInto(string language);
     }
 }

--- a/Jellyfin.Plugin.Bookshelf/Providers/ComicBookInfo/IComicBookInfoUtilities.cs
+++ b/Jellyfin.Plugin.Bookshelf/Providers/ComicBookInfo/IComicBookInfoUtilities.cs
@@ -1,0 +1,32 @@
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Providers;
+
+namespace Jellyfin.Plugin.Bookshelf.Providers.ComicBookInfo
+{
+    /// <summary>
+    /// Utilities to help read JSON metadata.
+    /// </summary>
+    public interface IComicBookInfoUtilities
+    {
+        /// <summary>
+        /// Read comic book metadata.
+        /// </summary>
+        /// <param name="comic">The comic to read metadata from.</param>
+        /// <returns>The resulting book.</returns>
+        Book? ReadComicBookMetadata(ComicBookInfoMetadata comic);
+
+        /// <summary>
+        /// Read people metadata.
+        /// </summary>
+        /// <param name="comic">The comic to read metadata from.</param>
+        /// <param name="metadataResult">The metadata result to update.</param>
+        void ReadPeopleMetadata(ComicBookInfoMetadata comic, MetadataResult<Book> metadataResult);
+
+        /// <summary>
+        /// Converts a language to the three letter iso name of the language.
+        /// </summary>
+        /// <param name="language">The language to convert.</param>
+        /// <returns>The language represented by an three letter iso name.</returns>
+        string? ReadCultureInfoAsThreeLetterIsoInto(string language);
+    }
+}

--- a/Jellyfin.Plugin.Bookshelf/Providers/ComicInfo/ComicInfoXmlUtilities.cs
+++ b/Jellyfin.Plugin.Bookshelf/Providers/ComicInfo/ComicInfoXmlUtilities.cs
@@ -21,7 +21,31 @@ namespace Jellyfin.Plugin.Bookshelf.Providers.ComicInfo
             var hasFoundMetadata = false;
 
             hasFoundMetadata |= ReadStringInto(xml, "ComicInfo/Title", title => book.Name = title);
-            hasFoundMetadata |= ReadStringInto(xml, "ComicInfo/AlternateSeries", title => book.OriginalTitle = title);
+            // this value is used internally only, as Jellyfin has no field to save it to
+            var isManga = false;
+
+            hasFoundMetadata |= ReadStringInto(xml, "ComicInfo/Title", title => book.Name = title);
+            hasFoundMetadata |= ReadStringInto(xml, "ComicInfo/Manga", manga =>
+            {
+                if (manga.Equals("Yes", StringComparison.OrdinalIgnoreCase))
+                {
+                    isManga = true;
+                }
+            });
+            hasFoundMetadata |= ReadStringInto(xml, "ComicInfo/AlternateSeries", title =>
+            {
+                if (isManga)
+                {
+                    // Software like ComicTagger (https://github.com/comictagger/comictagger) uses
+                    // this field for the original language name when tagging manga
+                    book.OriginalTitle = title;
+                }
+                else
+                {
+                    // Based on the The Anansi Project, some US comics can be part of cross-over
+                    // story arcs. This field is then used to specify an alternate series
+                }
+            });
             hasFoundMetadata |= ReadStringInto(xml, "ComicInfo/Series", series => book.SeriesName = series);
             hasFoundMetadata |= ReadIntInto(xml, "ComicInfo/Number", issue => book.IndexNumber = issue);
             hasFoundMetadata |= ReadStringInto(xml, "ComicInfo/Summary", summary => book.Overview = summary);

--- a/Jellyfin.Plugin.Bookshelf/Providers/ComicInfo/ComicInfoXmlUtilities.cs
+++ b/Jellyfin.Plugin.Bookshelf/Providers/ComicInfo/ComicInfoXmlUtilities.cs
@@ -37,7 +37,7 @@ namespace Jellyfin.Plugin.Bookshelf.Providers.ComicInfo
                 if (isManga)
                 {
                     // Software like ComicTagger (https://github.com/comictagger/comictagger) uses
-                    // this field for the original language name when tagging manga
+                    // this field for the series name in the original language when tagging manga
                     book.OriginalTitle = title;
                 }
                 else

--- a/tests/Jellyfin.Plugin.Bookshelf.Tests/ComicBookInfoProviderTest.cs
+++ b/tests/Jellyfin.Plugin.Bookshelf.Tests/ComicBookInfoProviderTest.cs
@@ -1,0 +1,253 @@
+using System;
+using Jellyfin.Plugin.Bookshelf.Providers.ComicBookInfo;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.IO;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+using Xunit;
+
+namespace Jellyfin.Plugin.Bookshelf.Tests;
+
+public class ComicBookInfoProviderTest
+{
+    private readonly ComicBookInfoFormat _comicBookInfoFormat;
+
+    private readonly ComicBookInfoProvider _uut;
+
+    public ComicBookInfoProviderTest()
+    {
+        _comicBookInfoFormat = GenerateTestData();
+
+        var fileSystem = Substitute.For<IFileSystem>();
+        var logger = Substitute.For<ILogger<ComicBookInfoProvider>>();
+        _uut = new ComicBookInfoProvider(fileSystem, logger);
+    }
+
+    [Fact]
+    public void ReadTitle_Success()
+    {
+        Assert.NotNull(_comicBookInfoFormat.Metadata);
+
+        var actual = _uut.ReadComicBookMetadata(_comicBookInfoFormat.Metadata!);
+        Assert.NotNull(actual);
+        Assert.Equal("At Midnight, All the Agents", actual!.Name);
+    }
+
+    [Fact(DisplayName = "Check that the series has no alternative title.")]
+    public void ReadAlternativeSeries_Success()
+    {
+        Assert.NotNull(_comicBookInfoFormat.Metadata);
+
+        var actual = _uut.ReadComicBookMetadata(_comicBookInfoFormat.Metadata!);
+        Assert.NotNull(actual);
+        Assert.Null(actual!.OriginalTitle);
+    }
+
+    [Fact]
+    public void ReadSeries_Success()
+    {
+        Assert.NotNull(_comicBookInfoFormat.Metadata);
+
+        var actual = _uut.ReadComicBookMetadata(_comicBookInfoFormat.Metadata!);
+        Assert.NotNull(actual);
+        Assert.Equal("Watchmen", actual!.SeriesName);
+    }
+
+    [Fact(DisplayName = "Check that the issue equals the index number.")]
+    public void ReadNumber_Success()
+    {
+        Assert.NotNull(_comicBookInfoFormat.Metadata);
+
+        var actual = _uut.ReadComicBookMetadata(_comicBookInfoFormat.Metadata!);
+        Assert.NotNull(actual);
+        Assert.Equal(1, actual!.IndexNumber);
+    }
+
+    [Fact]
+    public void ReadSummary_Success()
+    {
+        Assert.NotNull(_comicBookInfoFormat.Metadata);
+
+        var actual = _uut.ReadComicBookMetadata(_comicBookInfoFormat.Metadata!);
+        var expected = "Tales of the Black Freighter...";
+
+        Assert.NotNull(actual);
+        Assert.Equal(expected, actual!.Overview);
+    }
+
+    [Fact]
+    public void ReadProductionYear_Success()
+    {
+        Assert.NotNull(_comicBookInfoFormat.Metadata);
+
+        var actual = _uut.ReadComicBookMetadata(_comicBookInfoFormat.Metadata!);
+        Assert.NotNull(actual);
+        Assert.Equal(1986, actual!.ProductionYear);
+    }
+
+    [Fact]
+    public void ReadDate_Success()
+    {
+        Assert.NotNull(_comicBookInfoFormat.Metadata);
+
+        var actual = _uut.ReadComicBookMetadata(_comicBookInfoFormat.Metadata!);
+        var expected = new DateTime(1986, 9, 1);
+
+        Assert.NotNull(actual);
+        Assert.Equal(expected, actual!.PremiereDate);
+    }
+
+    [Fact]
+    public void ReadGenres_Success()
+    {
+        Assert.NotNull(_comicBookInfoFormat.Metadata);
+
+        var actual = _uut.ReadComicBookMetadata(_comicBookInfoFormat.Metadata!);
+        Assert.NotNull(actual);
+        Assert.Single(actual!.Genres);
+        Assert.Equal("Superhero", actual!.Genres.GetValue(0));
+    }
+
+    [Fact]
+    public void ReadPublisher_Success()
+    {
+        Assert.NotNull(_comicBookInfoFormat.Metadata);
+
+        var actual = _uut.ReadComicBookMetadata(_comicBookInfoFormat.Metadata!);
+        Assert.NotNull(actual);
+        Assert.Single(actual!.Studios);
+        Assert.Equal("DC Comics", actual!.Studios.GetValue(0));
+    }
+
+    [Fact]
+    public void ReadPeopleMetadata_Success()
+    {
+        var book = new Book();
+        var metadataResult = new MetadataResult<Book> { Item = book, HasMetadata = true };
+
+        Assert.NotNull(_comicBookInfoFormat.Metadata);
+        _uut.ReadPeopleMetadata(_comicBookInfoFormat.Metadata!, metadataResult);
+
+        var writer = new PersonInfo { Name = "Alan Moore", Type = "Writer" };
+        var artist = new PersonInfo { Name = "Dave Gibbons", Type = "Artist" };
+        var letterer = new PersonInfo { Name = "Dave Gibbons", Type = "Letterer" };
+        var colorer = new PersonInfo { Name = "John Gibbons", Type = "Colorer" };
+        var editor0 = new PersonInfo { Name = "Len Wein", Type = "Editor" };
+        var editor1 = new PersonInfo { Name = "Barbara Kesel", Type = "Editor" };
+        var example = new PersonInfo { Name = "Takashi Shimoyama", Type = "Example" };
+
+        Assert.Collection(
+            metadataResult.People,
+            writerActual =>
+            {
+                Assert.Equal(writer.Name, writerActual.Name);
+                Assert.Equal(writer.Type, writerActual.Type);
+            },
+            artistActual =>
+            {
+                Assert.Equal(artist.Name, artistActual.Name);
+                Assert.Equal(artist.Type, artistActual.Type);
+            },
+            lettererActual =>
+            {
+                Assert.Equal(letterer.Name, lettererActual.Name);
+                Assert.Equal(letterer.Type, lettererActual.Type);
+            },
+            colorerActual =>
+            {
+                Assert.Equal(colorer.Name, colorerActual.Name);
+                Assert.Equal(colorer.Type, colorerActual.Type);
+            },
+            editor0Actual =>
+            {
+                Assert.Equal(editor0.Name, editor0Actual.Name);
+                Assert.Equal(editor0.Type, editor0Actual.Type);
+            },
+            editor1Actual =>
+            {
+                Assert.Equal(editor1.Name, editor1Actual.Name);
+                Assert.Equal(editor1.Type, editor1Actual.Type);
+            },
+            exampleActual =>
+            {
+                Assert.Equal(example.Name, exampleActual.Name);
+                Assert.Equal(example.Type, exampleActual.Type);
+            });
+    }
+
+    [Fact]
+    public void ReadTags_Success()
+    {
+        Assert.NotNull(_comicBookInfoFormat.Metadata);
+        var actual = _uut.ReadComicBookMetadata(_comicBookInfoFormat.Metadata!);
+
+        var tags = new string[] { "Rorschach", "Ozymandias", "Nite Owl" };
+
+        Assert.NotNull(actual);
+        Assert.NotEmpty(actual!.Tags);
+        Assert.Collection(
+            actual!.Tags,
+            tag0 => Assert.Equal(tags[0], tag0),
+            tag1 => Assert.Equal(tags[1], tag1),
+            tag2 => Assert.Equal(tags[2], tag2));
+    }
+
+    // [Fact]
+    // public void ReadCultureInfoInto_Success()
+    // {
+    // Assert.NotNull(_comicBookInfoFormat.Metadata);
+    // Assert.NotNull(_comicBookInfoFormat.Metadata!.Language);
+    // var actualCultureInfo = _uut.ReadCultureInfoAsThreeLetterIsoInto(_comicBookInfoFormat.Metadata!.Language!);
+
+    // Assert.NotNull(actualCultureInfo);
+    // Console.WriteLine("language name: " + new CultureInfo("English").DisplayName);
+    // Console.WriteLine("two letter name: " + new CultureInfo("English").Get.TwoLetterISOLanguageName);
+    // Console.WriteLine("{0,-31}{1,-47}{2,-25}", "ThreeLetterISOLanguageName", new CultureInfo("English").ThreeLetterISOLanguageName, new CultureInfo("English").ThreeLetterISOLanguageName);
+    // Assert.Equal("en", actualCultureInfo);
+    // }
+
+    public ComicBookInfoFormat GenerateTestData()
+    {
+        // example data taken from https://code.google.com/archive/p/comicbookinfo/wikis/Example.wiki
+        var credits = new ComicBookInfoCredit[]
+        {
+            new ComicBookInfoCredit { Person = "Moore, Alan", Role = "Writer" },
+            new ComicBookInfoCredit { Person = "Gibbons, Dave", Role = "Artist" },
+            new ComicBookInfoCredit { Person = "Gibbons, Dave", Role = "Letterer" },
+            new ComicBookInfoCredit { Person = "Gibbons, John", Role = "Colorer" },
+            new ComicBookInfoCredit { Person = "Wein, Len", Role = "Editor" },
+            new ComicBookInfoCredit { Person = "Kesel, Barbara", Role = "Editor" },
+            // example of a non-comma-separated name
+            new ComicBookInfoCredit { Person = "Takashi Shimoyama", Role = "Example" }
+        };
+        var tags = new string[] { "Rorschach", "Ozymandias", "Nite Owl" };
+        var infoMetadata = new ComicBookInfoMetadata
+        {
+            Series = "Watchmen",
+            Title = "At Midnight, All the Agents",
+            Publisher = "DC Comics",
+            PublicationMonth = 9,
+            PublicationYear = 1986,
+            Issue = 1,
+            NumberOfIssues = 12,
+            Volume = 1,
+            NumberOfVolumes = 1,
+            Rating = 5,
+            Genre = "Superhero",
+            Language = "English",
+            Country = "United States",
+            Credits = credits,
+            Tags = tags,
+            Comments = "Tales of the Black Freighter...",
+        };
+        var infoFormat = new ComicBookInfoFormat
+        {
+            AppId = "ComicBookLover/888",
+            LastModified = "2009-10-25 14:51:31 +0000",
+            Metadata = infoMetadata
+        };
+
+        return infoFormat;
+    }
+}

--- a/tests/Jellyfin.Plugin.Bookshelf.Tests/ComicBookInfoProviderTest.cs
+++ b/tests/Jellyfin.Plugin.Bookshelf.Tests/ComicBookInfoProviderTest.cs
@@ -193,19 +193,16 @@ public class ComicBookInfoProviderTest
             tag2 => Assert.Equal(tags[2], tag2));
     }
 
-    // [Fact]
-    // public void ReadCultureInfoInto_Success()
-    // {
-    // Assert.NotNull(_comicBookInfoFormat.Metadata);
-    // Assert.NotNull(_comicBookInfoFormat.Metadata!.Language);
-    // var actualCultureInfo = _uut.ReadCultureInfoAsThreeLetterIsoInto(_comicBookInfoFormat.Metadata!.Language!);
+    [Fact]
+    public void ReadCultureInfoInto_Success()
+    {
+        Assert.NotNull(_comicBookInfoFormat.Metadata);
+        Assert.NotNull(_comicBookInfoFormat.Metadata!.Language);
+        var actualCultureInfo = _uut.ReadCultureInfoInto(_comicBookInfoFormat.Metadata!.Language!);
 
-    // Assert.NotNull(actualCultureInfo);
-    // Console.WriteLine("language name: " + new CultureInfo("English").DisplayName);
-    // Console.WriteLine("two letter name: " + new CultureInfo("English").Get.TwoLetterISOLanguageName);
-    // Console.WriteLine("{0,-31}{1,-47}{2,-25}", "ThreeLetterISOLanguageName", new CultureInfo("English").ThreeLetterISOLanguageName, new CultureInfo("English").ThreeLetterISOLanguageName);
-    // Assert.Equal("en", actualCultureInfo);
-    // }
+        Assert.NotNull(actualCultureInfo);
+        Assert.Equal("english", actualCultureInfo);
+    }
 
     public ComicBookInfoFormat GenerateTestData()
     {

--- a/tests/Jellyfin.Plugin.Bookshelf.Tests/ComicInfoXmlUtilitiesTest.cs
+++ b/tests/Jellyfin.Plugin.Bookshelf.Tests/ComicInfoXmlUtilitiesTest.cs
@@ -1,0 +1,226 @@
+using Xunit;
+using System;
+using System.Xml.Linq;
+using System.Globalization;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Controller.Entities;
+
+using Jellyfin.Plugin.Bookshelf.Providers.ComicInfo;
+
+namespace Jellyfin.Plugin.Bookshelf.Tests;
+
+public class ComicInfoXmlUtilitiesTest
+{
+
+    private readonly XDocument _document;
+    private readonly ComicInfoXmlUtilities _uut;
+
+    public ComicInfoXmlUtilitiesTest()
+    {
+        _document = GenerateTestData();
+        _uut = new ComicInfoXmlUtilities();
+    }
+
+    [Fact]
+    public void ReadTitle_Success()
+    {
+        var actual = _uut.ReadComicBookMetadata(_document);
+        Assert.NotNull(actual);
+        Assert.Equal("The Desperate Battle Begins!", actual!.Name);
+    }
+
+    [Fact]
+    public void ReadAlternativeSeries_Success()
+    {
+        var actual = _uut.ReadComicBookMetadata(_document);
+        Assert.NotNull(actual);
+        Assert.Equal("進撃の巨人", actual!.OriginalTitle);
+    }
+
+    [Fact]
+    public void ReadSeries_Success()
+    {
+        var actual = _uut.ReadComicBookMetadata(_document);
+        Assert.NotNull(actual);
+        Assert.Equal("Attack on Titan", actual!.SeriesName);
+    }
+
+    [Fact(DisplayName = "Check that the issue equals the index number.")]
+    public void ReadNumber_Success()
+    {
+        var actual = _uut.ReadComicBookMetadata(_document);
+        Assert.NotNull(actual);
+        Assert.Equal(1, actual!.IndexNumber);
+    }
+
+    [Fact]
+    public void ReadSummary_Success()
+    {
+        var actual = _uut.ReadComicBookMetadata(_document);
+        var expected = "Eren Jaeger lives in city surrounded by monolithic walls. Outside dwell human murdering Titans. For decades members of the " +
+            "Scouting Legion have been the only humans who dared to leave the safety of the walls and gather information on the Titans. Every time " +
+            "they return, many of them are dead. Freedom loving Eren has no greater wish than to join them. \n\n Chapter TitlesEpisode 1: To You, " +
+            "2,000 Years From NowEpisode 2: That DayEpisode 3: Night of the Disbanding CeremonyEpisode 4: First Battle";
+
+        Assert.NotNull(actual);
+        Assert.Equal(expected, actual!.Overview);
+    }
+
+    [Fact]
+    public void ReadProductionYear_Success()
+    {
+        var actual = _uut.ReadComicBookMetadata(_document);
+        Assert.NotNull(actual);
+        Assert.Equal(2012, actual!.ProductionYear);
+    }
+
+    [Fact]
+    public void ReadDate_Success()
+    {
+        var actual = _uut.ReadComicBookMetadata(_document);
+        var expected = new DateTime(2012, 6, 30);
+
+        Assert.NotNull(actual);
+        Assert.Equal(expected, actual!.PremiereDate);
+    }
+
+    [Fact]
+    public void ReadGenres_Success()
+    {
+        var actual = _uut.ReadComicBookMetadata(_document);
+        Assert.NotNull(actual);
+        Assert.NotEmpty(actual!.Genres);
+        Assert.Equal("Action", actual!.Genres.GetValue(0));
+        Assert.Equal("Dark fantasy", actual!.Genres.GetValue(1));
+        Assert.Equal("Post-apocalyptic", actual!.Genres.GetValue(2));
+    }
+
+    [Fact]
+    public void ReadPublisher_Success()
+    {
+        var actual = _uut.ReadComicBookMetadata(_document);
+        Assert.NotNull(actual);
+        Assert.Single(actual!.Studios);
+        Assert.Equal("Kodansha Comics USA", actual!.Studios.GetValue(0));
+    }
+
+    [Fact]
+    public void ReadPeopleMetadata_Success()
+    {
+        var book = new Book();
+        var metadataResult = new MetadataResult<Book> { Item = book, HasMetadata = true };
+
+        _uut.ReadPeopleMetadata(_document, metadataResult);
+
+        var author = new PersonInfo { Name = "Hajime Isayama", Type = "Author" };
+        var penciller = new PersonInfo { Name = "A Penciller", Type = "Penciller" };
+        var inker = new PersonInfo { Name = "An Inker", Type = "Inker" };
+        var letterer = new PersonInfo { Name = "Steve Wands", Type = "Letterer" };
+        var coverArtist0 = new PersonInfo { Name = "Artist A", Type = "Cover Artist" };
+        var coverArtist1 = new PersonInfo { Name = "Takashi Shimoyama", Type = "Cover Artist" };
+        var colourist = new PersonInfo { Name = "An Colourist", Type = "Colourist" };
+
+        Assert.Collection(metadataResult.People, _author =>
+            {
+                Assert.Equal(author.Name, authorActual.Name);
+                Assert.Equal(author.Type, authorActual.Type);
+            },
+            pencillerActual =>
+            {
+                Assert.Equal(penciller.Name, pencillerActual.Name);
+                Assert.Equal(penciller.Type, pencillerActual.Type);
+            },
+            inkerActual =>
+            {
+                Assert.Equal(inker.Name, inkerActual.Name);
+                Assert.Equal(inker.Type, inkerActual.Type);
+            },
+            lettererActual =>
+            {
+                Assert.Equal(letterer.Name, lettererActual.Name);
+                Assert.Equal(letterer.Type, lettererActual.Type);
+            },
+            coverArtist0Actual =>
+            {
+                Assert.Equal(coverArtist0.Name, coverArtist0Actual.Name);
+                Assert.Equal(coverArtist0.Type, coverArtist0Actual.Type);
+            },
+            coverArtist1Actual =>
+            {
+                Assert.Equal(coverArtist1.Name, coverArtist1Actual.Name);
+                Assert.Equal(coverArtist1.Type, coverArtist1Actual.Type);
+            },
+            colouristActual =>
+            {
+                Assert.Equal(colourist.Name, colouristActual.Name);
+                Assert.Equal(colourist.Type, colouristActual.Type);
+            });
+    }
+
+    [Fact]
+    public void ReadCultureInfoInto_Success()
+    {
+        var expectedCultureInfo = new CultureInfo("en");
+
+        bool expected = true;
+        bool actual = _uut.ReadCultureInfoInto(_document, "ComicInfo/LanguageISO", cultureInfo => Assert.Equal(cultureInfo.CompareInfo, expectedCultureInfo.CompareInfo));
+
+        Assert.True(actual == expected);
+    }
+
+    public XDocument GenerateTestData()
+    {
+        XDocument document = new XDocument(new XDeclaration("1.0", "", ""));
+
+        XNamespace xsi = XNamespace.Get("http://www.w3.org/2001/XMLSchema-instance");
+        XNamespace xsd = XNamespace.Get("http://www.w3.org/2001/XMLSchema");
+        XElement comicInfo = new XElement("ComicInfo", new XAttribute(XNamespace.Xmlns + "xsi", xsi), new XAttribute(XNamespace.Xmlns + "xsd", xsd));
+        document.Add(comicInfo);
+
+        comicInfo.Add(new XElement("Title", "The Desperate Battle Begins!"));
+        comicInfo.Add(new XElement("AlternateSeries", "進撃の巨人"));
+        comicInfo.Add(new XElement("Series", "Attack on Titan"));
+        comicInfo.Add(new XElement("Number", "1"));
+        comicInfo.Add(new XElement("Count", "1"));
+        comicInfo.Add(new XElement("Volume", "1"));
+        comicInfo.Add(new XElement("Summary", "Eren Jaeger lives in city surrounded by monolithic walls. Outside dwell human murdering Titans. For decades " +
+                "members of the Scouting Legion have been the only humans who dared to leave the safety of the walls and gather information on the Titans. " +
+                "Every time they return, many of them are dead. Freedom loving Eren has no greater wish than to join them. \n\n Chapter TitlesEpisode 1: " +
+                "To You, 2,000 Years From NowEpisode 2: That DayEpisode 3: Night of the Disbanding CeremonyEpisode 4: First Battle"));
+        comicInfo.Add(new XElement("Notes", "Tagged with ComicTagger 1.3.0a0 using info from Comic Vine on 2021-07-24 01:15:20.  [Issue ID 342215]"));
+        comicInfo.Add(new XElement("Year", "2012"));
+        comicInfo.Add(new XElement("Month", "6"));
+        comicInfo.Add(new XElement("Day", "30"));
+        comicInfo.Add(new XElement("Writer", "Hajime Isayama"));
+        comicInfo.Add(new XElement("Penciller", "A Penciller"));
+        comicInfo.Add(new XElement("Inker", "An Inker"));
+        comicInfo.Add(new XElement("Colourist", "An Colourist"));
+        comicInfo.Add(new XElement("Letterer", "Steve Wands"));
+        comicInfo.Add(new XElement("CoverArtist", "Artist A, Takashi Shimoyama"));
+        comicInfo.Add(new XElement("Publisher", "Kodansha Comics USA"));
+        comicInfo.Add(new XElement("Genre", "Action, Dark fantasy, Post-apocalyptic"));
+        comicInfo.Add(new XElement("Web", "https://comicvine.gamespot.com/attack-on-titan-1-the-desperate-battle-begins/4000-342215"));
+        comicInfo.Add(new XElement("PageCount", "210"));
+        comicInfo.Add(new XElement("LanguageISO", "en"));
+        comicInfo.Add(new XElement("Format", "Black & White"));
+        comicInfo.Add(new XElement("Manga", "Yes"));
+        comicInfo.Add(new XElement("Characters", "Annie Leonhart, Armin Arlert, Bertolt Hoover, Carla Yeager, Connie Springer, Eren Yeager, Franz Kefka, " +
+                "Grisha Yeager, Hannah Diamant, Hannes, Jean Kirstein, Krista Lenz, Marco Bott, Mikasa Ackerman, Mina Carolina, Reiner Braun, Samuel " +
+                "Linke-Jackson, Sasha Blouse, Thomas Wagner"));
+        comicInfo.Add(new XElement("Teams", "Titans"));
+        comicInfo.Add(new XElement("Locations", "Shiganshina District, Trost District, Wall Maria, Wall Rose"));
+        comicInfo.Add(new XElement("ScanInformation", "vol1"));
+
+        // add the cover page and example pages
+        XElement pages = new XElement("Pages");
+        comicInfo.Add(pages);
+        pages.Add(new XElement("Page", new XAttribute("Image", "0"), new XAttribute("Type", "FrontCover"), new XAttribute("ImageSize", "41911")));
+        // add the remaining 209 pages, starting from 1, as page 0 has already been added
+        for (int i = 1; i <= 210; i++)
+        {
+            pages.Add(new XElement("Page", new XAttribute("Image", i), new XAttribute("ImageSize", "14922")));
+        }
+
+        return document;
+    }
+}

--- a/tests/Jellyfin.Plugin.Bookshelf.Tests/ComicInfoXmlUtilitiesTest.cs
+++ b/tests/Jellyfin.Plugin.Bookshelf.Tests/ComicInfoXmlUtilitiesTest.cs
@@ -219,10 +219,12 @@ public class ComicInfoXmlUtilitiesTest
         // add the cover page and example pages
         XElement pages = new XElement("Pages");
         comicInfo.Add(pages);
+        // image size is arbitary chosen instead of using a real image size (in bytes) for each page
         pages.Add(new XElement("Page", new XAttribute("Image", "0"), new XAttribute("Type", "FrontCover"), new XAttribute("ImageSize", "41911")));
         // add the remaining 209 pages, starting from 1, as page 0 has already been added
         for (int i = 1; i <= 210; i++)
         {
+            // image size is arbitary chosen instead of using a real image size (in bytes) for each page
             pages.Add(new XElement("Page", new XAttribute("Image", i), new XAttribute("ImageSize", "14922")));
         }
 

--- a/tests/Jellyfin.Plugin.Bookshelf.Tests/ComicInfoXmlUtilitiesTest.cs
+++ b/tests/Jellyfin.Plugin.Bookshelf.Tests/ComicInfoXmlUtilitiesTest.cs
@@ -36,7 +36,7 @@ public class ComicInfoXmlUtilitiesTest
         // story arcs. This field is used to specify an alternate series
         // https://anansi-project.github.io/docs/comicinfo/documentation#alternateseries--alternatenumber--alternatecount
         // However, software like ComicTagger (https://github.com/comictagger/comictagger) uses
-        // this field for the original language name when tagging manga
+        // this field for the series name in the original language when tagging manga
         var actual = _uut.ReadComicBookMetadata(_document);
         Assert.NotNull(actual);
         Assert.Equal("進撃の巨人", actual!.OriginalTitle);

--- a/tests/Jellyfin.Plugin.Bookshelf.Tests/ComicInfoXmlUtilitiesTest.cs
+++ b/tests/Jellyfin.Plugin.Bookshelf.Tests/ComicInfoXmlUtilitiesTest.cs
@@ -125,7 +125,7 @@ public class ComicInfoXmlUtilitiesTest
         var coverArtist1 = new PersonInfo { Name = "Takashi Shimoyama", Type = "Cover Artist" };
         var colourist = new PersonInfo { Name = "An Colourist", Type = "Colourist" };
 
-        Assert.Collection(metadataResult.People, _author =>
+        Assert.Collection(metadataResult.People, authorActual =>
             {
                 Assert.Equal(author.Name, authorActual.Name);
                 Assert.Equal(author.Type, authorActual.Type);

--- a/tests/Jellyfin.Plugin.Bookshelf.Tests/ComicInfoXmlUtilitiesTest.cs
+++ b/tests/Jellyfin.Plugin.Bookshelf.Tests/ComicInfoXmlUtilitiesTest.cs
@@ -32,6 +32,11 @@ public class ComicInfoXmlUtilitiesTest
     [Fact]
     public void ReadAlternativeSeries_Success()
     {
+        // Based on the The Anansi Project, some US comics can be part of cross-over
+        // story arcs. This field is used to specify an alternate series
+        // https://anansi-project.github.io/docs/comicinfo/documentation#alternateseries--alternatenumber--alternatecount
+        // However, software like ComicTagger (https://github.com/comictagger/comictagger) uses
+        // this field for the original language name when tagging manga
         var actual = _uut.ReadComicBookMetadata(_document);
         Assert.NotNull(actual);
         Assert.Equal("進撃の巨人", actual!.OriginalTitle);

--- a/tests/Jellyfin.Plugin.Bookshelf.Tests/Jellyfin.Plugin.Bookshelf.Tests.csproj
+++ b/tests/Jellyfin.Plugin.Bookshelf.Tests/Jellyfin.Plugin.Bookshelf.Tests.csproj
@@ -12,6 +12,10 @@
     <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="NSubstitute" Version="4.4.0" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.15">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/tests/Jellyfin.Plugin.Bookshelf.Tests/Jellyfin.Plugin.Bookshelf.Tests.csproj
+++ b/tests/Jellyfin.Plugin.Bookshelf.Tests/Jellyfin.Plugin.Bookshelf.Tests.csproj
@@ -10,18 +10,18 @@
 
   <ItemGroup>
     <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
-    <PackageReference Include="NSubstitute" Version="4.4.0" />
-    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.15">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
+    <PackageReference Include="NSubstitute.Analyzers.CSharp" Version="1.0.16">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="xunit" Version="2.5.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/Jellyfin.Plugin.Bookshelf.Tests/Jellyfin.Plugin.Bookshelf.Tests.csproj
+++ b/tests/Jellyfin.Plugin.Bookshelf.Tests/Jellyfin.Plugin.Bookshelf.Tests.csproj
@@ -1,0 +1,30 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
+    <PackageReference Include="NSubstitute" Version="4.4.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.1.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Jellyfin.Plugin.Bookshelf\Jellyfin.Plugin.Bookshelf.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Add unit tests for the ComicInfo and ComicBookInfo format using xunit and NSubstitute. While adding the unit tests, I found a few bugs that I fixed as well.

The test data for the  ComicBookInfo unit test is taken from the documentation of the format: https://code.google.com/archive/p/comicbookinfo/wikis/Example.wiki
The test data for the ComicInfo unit test is real data from an actual manga. There is one exception to this: The image size of the pages is an arbitrary chosen value instead of using the real image size (stored in bytes).

In either case, I provided **more test data than is actually tested against**. This should allow developers who do not own comics / mangas to contribute by testing their changes against the test data. This could  **serve as a reference to add missing fields to the Jellyfin Server** to allow the plugin to save the entire metadata to the server and then let clients use those additional metadata fields for their own purposes (e.g. reading direction for manga).

No unit tests for the epub format as I ran out of time. :/