### PR TITLE
Improve title handling of epub files

### DIFF
--- a/Jellyfin.Plugin.Bookshelf/Providers/OpfReader.cs
+++ b/Jellyfin.Plugin.Bookshelf/Providers/OpfReader.cs
@@ -179,7 +179,7 @@ namespace Jellyfin.Plugin.Bookshelf.Providers
                     string titleType = titleNode.InnerText;
 
                     var titleElement = _document.SelectSingleNode($"//dc:title[@id='{refines}']", _namespaceManager);
-                    if (titleElement is not null && titleType is "main")
+                    if (titleElement is not null && string.Equals(titleType, "main", StringComparison.OrdinalIgnoreCase))
                     {
                         title = titleElement.InnerText;
                     }


### PR DESCRIPTION
A epub file may contain multiple titles. As Jellyfin only supports one title, we want to make sure it is the main title.

Additionally, the title_sort attribute is read in.