### PR TITLE
Improve cover image extraction from epub files

### DIFF
--- a/.github/workflows/publish-unstable.yaml
+++ b/.github/workflows/publish-unstable.yaml
@@ -1,0 +1,16 @@
+name: '🚀 Publish (Unstable) Plugin'
+
+on:
+  push:
+    branches:
+      - unstable
+  workflow_dispatch:
+
+jobs:
+  call:
+    uses: jellyfin/jellyfin-meta-plugins/.github/workflows/publish-unstable.yaml@master
+    secrets:
+      deploy-host: ${{ secrets.REPO_HOST }}
+      deploy-user: ${{ secrets.REPO_USER }}
+      deploy-key: ${{ secrets.REPO_KEY }}
+      token: ${{ secrets.JF_BOT_TOKEN }}

--- a/Jellyfin.Plugin.Bookshelf/Providers/Epub/EpubMetadataImageProvider.cs
+++ b/Jellyfin.Plugin.Bookshelf/Providers/Epub/EpubMetadataImageProvider.cs
@@ -102,7 +102,7 @@ namespace Jellyfin.Plugin.Bookshelf.Providers.Epub
             }
 
             var opfRootDirectory = Path.GetDirectoryName(opfFilePath);
-            if (string.IsNullOrEmpty(opfRootDirectory))
+            if (opfRootDirectory == null)
             {
                 return new DynamicImageResponse { HasImage = false };
             }

--- a/Jellyfin.Plugin.Bookshelf/Providers/OpfReader.cs
+++ b/Jellyfin.Plugin.Bookshelf/Providers/OpfReader.cs
@@ -54,13 +54,13 @@ namespace Jellyfin.Plugin.Bookshelf.Providers
                 return coverImage;
             }
 
-            var coverId = ReadEpubCoverInto(opfRootDirectory, "//opf:item[@id='cover']");
+            var coverId = ReadEpubCoverInto(opfRootDirectory, "//opf:item[@id='cover' and @media-type='image/*']");
             if (coverId is not null)
             {
                 return coverId;
             }
 
-            var coverImageId = ReadEpubCoverInto(opfRootDirectory, "//opf:item[@id='cover-image']");
+            var coverImageId = ReadEpubCoverInto(opfRootDirectory, "//opf:item[@id='*cover-image']");
             if (coverImageId is not null)
             {
                 return coverImageId;
@@ -238,7 +238,7 @@ namespace Jellyfin.Plugin.Bookshelf.Providers
             {
                 try
                 {
-                    commitResult(Convert.ToInt32(resultValue, CultureInfo.InvariantCulture));
+                    commitResult(Convert.ToInt32(Convert.ToDouble(resultValue, CultureInfo.InvariantCulture)));
                 }
                 catch (Exception e)
                 {


### PR DESCRIPTION
This is to improve the cover image extraction from the epub file.

I have 754 epub files under Jellyfin management and only 5 of them have cover image correctly extracted.
With below 3 improvements, all 754 files can be processed well.

1. Treat calibre:series_index as Double before converting to Int32.
2. Accept empty opfRootDirectory.
3. Improve xPath for cover image object finding.

More details can be found at https://github.com/jellyfin/jellyfin-plugin-bookshelf/issues/100#issuecomment-2054013821