### PR TITLE
Add support for covers from .cbt, .cb7 and .cbr

### DIFF
--- a/Jellyfin.Plugin.Bookshelf/Jellyfin.Plugin.Bookshelf.csproj
+++ b/Jellyfin.Plugin.Bookshelf/Jellyfin.Plugin.Bookshelf.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -13,7 +13,7 @@
   <ItemGroup>
     <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-    <PackageReference Include="sharpcompress" Version="0.36.0" />
+    <PackageReference Include="SharpCompress" Version="0.38.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/build.yaml
+++ b/build.yaml
@@ -12,6 +12,8 @@ description: >
 category: "Metadata"
 artifacts:
   - "Jellyfin.Plugin.Bookshelf.dll"
+  - "SharpCompress.dll"
+  - "ZstdSharp.dll"
 changelog: |-
   - Unstable (#103) @crobibero
   - Improve cover image extraction from epub files (#102) @unfedorg


### PR DESCRIPTION
This PR adds support for extracting covers from .cbt, .cb7 and .cbr, in addition to the existing support for .cbz

![image](https://github.com/user-attachments/assets/bfa5e312-e50d-4f2c-bc5f-ee23f2ec60c2)
