### PR TITLE
Implement a new feature to extract cover images from PDF files

### DIFF
--- a/Jellyfin.Plugin.Bookshelf/Jellyfin.Plugin.Bookshelf.csproj
+++ b/Jellyfin.Plugin.Bookshelf/Jellyfin.Plugin.Bookshelf.csproj
@@ -16,8 +16,9 @@
 
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.1" />
     <PackageReference Include="SharpCompress" Version="0.38.0" />
+    <!-- Follow what Jellyfin server pinned. https://github.com/jellyfin/jellyfin/pull/14255 -->
+    <PackageReference Include="SkiaSharp" Version="3.116.1" />
     <PackageReference Include="PDFtoImage" Version="4.1.1" />
-    <PackageReference Include="SkiaSharp" Version="3.116.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Jellyfin.Plugin.Bookshelf/Jellyfin.Plugin.Bookshelf.csproj
+++ b/Jellyfin.Plugin.Bookshelf/Jellyfin.Plugin.Bookshelf.csproj
@@ -8,12 +8,16 @@
     <AnalysisMode>AllEnabledByDefault</AnalysisMode>
     <CodeAnalysisRuleSet>../jellyfin.ruleset</CodeAnalysisRuleSet>
     <Nullable>enable</Nullable>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
+
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.1" />
     <PackageReference Include="SharpCompress" Version="0.38.0" />
+    <PackageReference Include="PDFtoImage" Version="4.1.1" />
+    <PackageReference Include="SkiaSharp" Version="3.116.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -26,4 +30,23 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" />
   </ItemGroup>
 
+    <Target Name="RenameWindowsNativeLibs" AfterTargets="Build">
+  <Move SourceFiles="$(OutputPath)runtimes/win-x64/native/pdfium.dll"
+        DestinationFiles="$(OutputPath)runtimes/win-x64/native/pdfium.dll.win"
+        Condition="Exists('$(OutputPath)runtimes/win-x64/native/pdfium.dll')" />
+
+  <Move SourceFiles="$(OutputPath)runtimes/win-arm64/native/pdfium.dll"
+        DestinationFiles="$(OutputPath)runtimes/win-arm64/native/pdfium.dll.win"
+        Condition="Exists('$(OutputPath)runtimes/win-arm64/native/pdfium.dll')" />
+</Target>
+
+<Target Name="RenameWindowsNativeLibsPublish" AfterTargets="Publish">
+  <Move SourceFiles="$(PublishDir)runtimes/win-x64/native/pdfium.dll"
+        DestinationFiles="$(PublishDir)runtimes/win-x64/native/pdfium.dll.win"
+        Condition="Exists('$(PublishDir)runtimes/win-x64/native/pdfium.dll')" />
+
+  <Move SourceFiles="$(PublishDir)runtimes/win-arm64/native/pdfium.dll"
+        DestinationFiles="$(PublishDir)runtimes/win-arm64/native/pdfium.dll.win"
+        Condition="Exists('$(PublishDir)runtimes/win-arm64/native/pdfium.dll')" />
+</Target>
 </Project>

--- a/Jellyfin.Plugin.Bookshelf/Jellyfin.Plugin.Bookshelf.csproj
+++ b/Jellyfin.Plugin.Bookshelf/Jellyfin.Plugin.Bookshelf.csproj
@@ -13,7 +13,6 @@
 
   <ItemGroup>
     <PackageReference Include="Jellyfin.Controller" Version="10.*-*" />
-
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.1" />
     <PackageReference Include="SharpCompress" Version="0.38.0" />
     <!-- Follow what Jellyfin server pinned. https://github.com/jellyfin/jellyfin/pull/14255 -->

--- a/Jellyfin.Plugin.Bookshelf/Jellyfin.Plugin.Bookshelf.csproj
+++ b/Jellyfin.Plugin.Bookshelf/Jellyfin.Plugin.Bookshelf.csproj
@@ -30,23 +30,23 @@
     <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.556" PrivateAssets="All" />
   </ItemGroup>
 
-    <Target Name="RenameWindowsNativeLibs" AfterTargets="Build">
-  <Move SourceFiles="$(OutputPath)runtimes/win-x64/native/pdfium.dll"
-        DestinationFiles="$(OutputPath)runtimes/win-x64/native/pdfium.dll.win"
-        Condition="Exists('$(OutputPath)runtimes/win-x64/native/pdfium.dll')" />
+  <Target Name="RenameWindowsNativeLibs" AfterTargets="Build">
+    <Move SourceFiles="$(OutputPath)runtimes/win-x64/native/pdfium.dll"
+      DestinationFiles="$(OutputPath)runtimes/win-x64/native/pdfium.dll.win"
+      Condition="Exists('$(OutputPath)runtimes/win-x64/native/pdfium.dll')" />
 
-  <Move SourceFiles="$(OutputPath)runtimes/win-arm64/native/pdfium.dll"
-        DestinationFiles="$(OutputPath)runtimes/win-arm64/native/pdfium.dll.win"
-        Condition="Exists('$(OutputPath)runtimes/win-arm64/native/pdfium.dll')" />
-</Target>
+    <Move SourceFiles="$(OutputPath)runtimes/win-arm64/native/pdfium.dll"
+      DestinationFiles="$(OutputPath)runtimes/win-arm64/native/pdfium.dll.win"
+      Condition="Exists('$(OutputPath)runtimes/win-arm64/native/pdfium.dll')" />
+  </Target>
 
-<Target Name="RenameWindowsNativeLibsPublish" AfterTargets="Publish">
-  <Move SourceFiles="$(PublishDir)runtimes/win-x64/native/pdfium.dll"
-        DestinationFiles="$(PublishDir)runtimes/win-x64/native/pdfium.dll.win"
-        Condition="Exists('$(PublishDir)runtimes/win-x64/native/pdfium.dll')" />
+  <Target Name="RenameWindowsNativeLibsPublish" AfterTargets="Publish">
+    <Move SourceFiles="$(PublishDir)runtimes/win-x64/native/pdfium.dll"
+      DestinationFiles="$(PublishDir)runtimes/win-x64/native/pdfium.dll.win"
+      Condition="Exists('$(PublishDir)runtimes/win-x64/native/pdfium.dll')" />
 
-  <Move SourceFiles="$(PublishDir)runtimes/win-arm64/native/pdfium.dll"
-        DestinationFiles="$(PublishDir)runtimes/win-arm64/native/pdfium.dll.win"
-        Condition="Exists('$(PublishDir)runtimes/win-arm64/native/pdfium.dll')" />
-</Target>
+    <Move SourceFiles="$(PublishDir)runtimes/win-arm64/native/pdfium.dll"
+      DestinationFiles="$(PublishDir)runtimes/win-arm64/native/pdfium.dll.win"
+      Condition="Exists('$(PublishDir)runtimes/win-arm64/native/pdfium.dll')" />
+  </Target>
 </Project>

--- a/Jellyfin.Plugin.Bookshelf/Plugin.cs
+++ b/Jellyfin.Plugin.Bookshelf/Plugin.cs
@@ -25,45 +25,45 @@ namespace Jellyfin.Plugin.Bookshelf
         {
             Instance = this;
             NativeLibrary.SetDllImportResolver(typeof(PDFtoImage.Conversion).Assembly, (libraryName, assembly, searchPath) =>
-        {
-            if (libraryName == "pdfium")
             {
-                string arch = RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? "arm64" : "x64";
-                string osPrefix = string.Empty;
-                string libName = string.Empty;
+                if (libraryName == "pdfium")
+                {
+                    string arch = RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? "arm64" : "x64";
+                    string osPrefix = string.Empty;
+                    string libName = string.Empty;
 
-                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-                {
-                    osPrefix = "linux";
-                    libName = "libpdfium.so";
-                }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-                {
-                    osPrefix = "osx";
-                    libName = "libpdfium.dylib";
-                }
-                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-                {
-                    osPrefix = "win";
-                    // Holding windows dlls with .dll.win extention to avoid Jellyfin from trying to load them by itself
-                    libName = "pdfium.dll.win";
-                }
-
-                if (!string.IsNullOrEmpty(osPrefix))
-                {
-                    string rid = $"{osPrefix}-{arch}";
-                    string pluginFolder = Path.GetDirectoryName(typeof(Plugin).Assembly.Location)!;
-                    string nativePath = Path.Join(pluginFolder, "runtimes", rid, "native", libName);
-
-                    if (File.Exists(nativePath))
+                    if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                     {
-                        return NativeLibrary.Load(nativePath);
+                        osPrefix = "linux";
+                        libName = "libpdfium.so";
+                    }
+                    else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                    {
+                        osPrefix = "osx";
+                        libName = "libpdfium.dylib";
+                    }
+                    else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                    {
+                        osPrefix = "win";
+                        // Holding windows dlls with .dll.win extention to avoid Jellyfin from trying to load them by itself
+                        libName = "pdfium.dll.win";
+                    }
+
+                    if (!string.IsNullOrEmpty(osPrefix))
+                    {
+                        string rid = $"{osPrefix}-{arch}";
+                        string pluginFolder = Path.GetDirectoryName(typeof(Plugin).Assembly.Location)!;
+                        string nativePath = Path.Join(pluginFolder, "runtimes", rid, "native", libName);
+
+                        if (File.Exists(nativePath))
+                        {
+                            return NativeLibrary.Load(nativePath);
+                        }
                     }
                 }
-            }
 
-            return IntPtr.Zero;
-        });
+                return IntPtr.Zero;
+            });
         }
 
         /// <inheritdoc />

--- a/Jellyfin.Plugin.Bookshelf/Plugin.cs
+++ b/Jellyfin.Plugin.Bookshelf/Plugin.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
 using Jellyfin.Plugin.Bookshelf.Configuration;
 using MediaBrowser.Common.Configuration;
 using MediaBrowser.Common.Plugins;
@@ -22,6 +24,46 @@ namespace Jellyfin.Plugin.Bookshelf
             : base(applicationPaths, xmlSerializer)
         {
             Instance = this;
+            NativeLibrary.SetDllImportResolver(typeof(PDFtoImage.Conversion).Assembly, (libraryName, assembly, searchPath) =>
+        {
+            if (libraryName == "pdfium")
+            {
+                string arch = RuntimeInformation.ProcessArchitecture == Architecture.Arm64 ? "arm64" : "x64";
+                string osPrefix = string.Empty;
+                string libName = string.Empty;
+
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+                {
+                    osPrefix = "linux";
+                    libName = "libpdfium.so";
+                }
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+                {
+                    osPrefix = "osx";
+                    libName = "libpdfium.dylib";
+                }
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    osPrefix = "win";
+                    // Holding windows dlls with .dll.win extention to avoid Jellyfin from trying to load them by itself
+                    libName = "pdfium.dll.win";
+                }
+
+                if (!string.IsNullOrEmpty(osPrefix))
+                {
+                    string rid = $"{osPrefix}-{arch}";
+                    string pluginFolder = Path.GetDirectoryName(typeof(Plugin).Assembly.Location)!;
+                    string nativePath = Path.Join(pluginFolder, "runtimes", rid, "native", libName);
+
+                    if (File.Exists(nativePath))
+                    {
+                        return NativeLibrary.Load(nativePath);
+                    }
+                }
+            }
+
+            return IntPtr.Zero;
+        });
         }
 
         /// <inheritdoc />

--- a/Jellyfin.Plugin.Bookshelf/Providers/PDFCoverProvider.cs
+++ b/Jellyfin.Plugin.Bookshelf/Providers/PDFCoverProvider.cs
@@ -12,7 +12,7 @@ using Microsoft.Extensions.Logging;
 using PDFtoImage;
 using SkiaSharp;
 
-namespace Jellyfin.Plugin.Pdfcover.Providers
+namespace Jellyfin.Plugin.Bookshelf.Providers
 {
     /// <summary>
     /// PDF cover provider.

--- a/Jellyfin.Plugin.Bookshelf/Providers/PDFCoverProvider.cs
+++ b/Jellyfin.Plugin.Bookshelf/Providers/PDFCoverProvider.cs
@@ -91,7 +91,7 @@ namespace Jellyfin.Plugin.Bookshelf.Providers
                     },
                     cancellationToken).ConfigureAwait(false);
             }
-            catch (Exception e) when (e is IOException || e is UnauthorizedAccessException || e is InvalidOperationException || e is ArgumentException || e is NotSupportedException)
+            catch (Exception e) when (e is IOException || e is UnauthorizedAccessException || e is InvalidOperationException || e is ArgumentException || e is NotSupportedException || e is PDFtoImage.Exceptions.PdfInvalidFormatException)
             {
                 // Log and return nothing
                 _logger.LogError(e, "Failed to load cover from {Path}", item.Path);

--- a/Jellyfin.Plugin.Bookshelf/Providers/PDFCoverProvider.cs
+++ b/Jellyfin.Plugin.Bookshelf/Providers/PDFCoverProvider.cs
@@ -91,7 +91,7 @@ namespace Jellyfin.Plugin.Bookshelf.Providers
                     },
                     cancellationToken).ConfigureAwait(false);
             }
-            catch (Exception e)
+            catch (Exception e) when (e is IOException || e is UnauthorizedAccessException || e is InvalidOperationException || e is ArgumentException || e is NotSupportedException)
             {
                 // Log and return nothing
                 _logger.LogError(e, "Failed to load cover from {Path}", item.Path);

--- a/Jellyfin.Plugin.Bookshelf/Providers/PDFCoverProvider.cs
+++ b/Jellyfin.Plugin.Bookshelf/Providers/PDFCoverProvider.cs
@@ -1,0 +1,102 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Drawing;
+using MediaBrowser.Model.Entities;
+using Microsoft.Extensions.Logging;
+using PDFtoImage;
+using SkiaSharp;
+
+namespace Jellyfin.Plugin.Pdfcover.Providers
+{
+    /// <summary>
+    /// PDF cover provider.
+    /// </summary>
+    public class PDFCoverProvider : IDynamicImageProvider
+    {
+        private readonly string _pdfExtension = ".pdf";
+        private readonly ILogger<PDFCoverProvider> _logger;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="PDFCoverProvider"/> class.
+        /// </summary>
+        /// <param name="logger">Instance of the <see cref="ILogger{PDFCoverProvider}"/> interface.</param>
+        public PDFCoverProvider(ILogger<PDFCoverProvider> logger)
+        {
+            _logger = logger;
+        }
+
+        /// <inheritdoc />
+        public string Name => "PDF Cover Generator";
+
+        /// <inheritdoc />
+        public bool Supports(BaseItem item)
+        {
+            return item is Book;
+        }
+
+        /// <inheritdoc />
+        public IEnumerable<ImageType> GetSupportedImages(BaseItem item)
+        {
+            yield return ImageType.Primary;
+        }
+
+        /// <inheritdoc />
+        public async Task<DynamicImageResponse> GetImage(BaseItem item, ImageType type, CancellationToken cancellationToken)
+        {
+            if (!string.Equals(Path.GetExtension(item.Path), _pdfExtension, StringComparison.OrdinalIgnoreCase))
+            {
+                return new DynamicImageResponse { HasImage = false };
+            }
+
+            _logger.LogInformation("Attempting to create PDF cover for {Path}", item.Path);
+            try
+            {
+                // Run the synchronous PDF conversion in a background thread
+                return await Task.Run(
+                    () =>
+                    {
+                        using var fileStream = File.OpenRead(item.Path);
+                        var ms = new MemoryStream();
+
+#pragma warning disable CA1416
+                        using var bitmap = Conversion.ToImage(fileStream, 0);
+#pragma warning restore CA1416
+
+                        if (bitmap == null)
+                        {
+                            return new DynamicImageResponse { HasImage = false };
+                        }
+
+                        using (var image = SKImage.FromBitmap(bitmap))
+                        using (var data = image.Encode(SKEncodedImageFormat.Jpeg, 90))
+                        {
+                            data.SaveTo(ms);
+                        }
+
+                        ms.Position = 0;
+
+                        _logger.LogInformation("Successfully created PDF cover for {Path}", item.Path);
+                        return new DynamicImageResponse
+                        {
+                            HasImage = true,
+                            Stream = ms,
+                            Format = ImageFormat.Jpg,
+                        };
+                    },
+                    cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                // Log and return nothing
+                _logger.LogError(e, "Failed to load cover from {Path}", item.Path);
+                return new DynamicImageResponse { HasImage = false };
+            }
+        }
+    }
+}

--- a/build.yaml
+++ b/build.yaml
@@ -14,5 +14,13 @@ artifacts:
   - "Jellyfin.Plugin.Bookshelf.dll"
   - "SharpCompress.dll"
   - "ZstdSharp.dll"
+  - "PDFtoImage.dll"
+  - "SkiaSharp.dll"
+  - "runtimes/linux-arm64/native/libpdfium.so"
+  - "runtimes/linux-x64/native/libpdfium.so"
+  - "runtimes/osx-arm64/native/libpdfium.dylib"
+  - "runtimes/osx-x64/native/libpdfium.dylib"
+  - "runtimes/win-arm64/native/pdfium.dll.win"
+  - "runtimes/win-x64/native/pdfium.dll.win"
 changelog: |-
   - Jellyfin 10.11 support (#130) @crobibero

--- a/tests/Jellyfin.Plugin.Bookshelf.Tests/Jellyfin.Plugin.Bookshelf.Tests.csproj
+++ b/tests/Jellyfin.Plugin.Bookshelf.Tests/Jellyfin.Plugin.Bookshelf.Tests.csproj
@@ -27,7 +27,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Moq" Version="4.20.70" />
-    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.116.0" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.116.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Jellyfin.Plugin.Bookshelf.Tests/Jellyfin.Plugin.Bookshelf.Tests.csproj
+++ b/tests/Jellyfin.Plugin.Bookshelf.Tests/Jellyfin.Plugin.Bookshelf.Tests.csproj
@@ -26,6 +26,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="SkiaSharp.NativeAssets.Linux" Version="3.116.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -38,4 +40,9 @@
     </None>
   </ItemGroup>
 
+  <ItemGroup>
+    <None Update="TestAssets/*">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
 </Project>

--- a/tests/Jellyfin.Plugin.Bookshelf.Tests/PDFCoverProviderTests.cs
+++ b/tests/Jellyfin.Plugin.Bookshelf.Tests/PDFCoverProviderTests.cs
@@ -1,0 +1,125 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+using Jellyfin.Plugin.Pdfcover.Providers;
+using MediaBrowser.Controller.Entities;
+using MediaBrowser.Controller.Providers;
+using MediaBrowser.Model.Drawing;
+using MediaBrowser.Model.Entities;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace Jellyfin.Plugin.PDFCover.Tests
+{
+    public class PDFCoverProviderTests
+    {
+        private readonly PDFCoverProvider _provider;
+        private readonly Mock<ILogger<PDFCoverProvider>> _loggerMock;
+
+        public PDFCoverProviderTests()
+        {
+            _loggerMock = new Mock<ILogger<PDFCoverProvider>>();
+            _provider = new PDFCoverProvider(_loggerMock.Object);
+        }
+
+        [Fact]
+        public void Name_Returns_CorrectName()
+        {
+            Assert.Equal("PDF Cover Generator", _provider.Name);
+        }
+
+        [Fact]
+        public void Supports_GivenBook_ReturnsTrue()
+        {
+            Assert.True(_provider.Supports(new Book()));
+        }
+
+        [Fact]
+        public void Supports_GivenNonBook_ReturnsFalse()
+        {
+            // Use Folder as a representative non-book type
+            Assert.False(_provider.Supports(new Folder()));
+        }
+
+        [Fact]
+        public void GetSupportedImages_Returns_Primary()
+        {
+            var supportedImages = _provider.GetSupportedImages(new Book());
+            Assert.Single(supportedImages);
+            Assert.Equal(ImageType.Primary, supportedImages.First());
+        }
+
+        [Fact]
+        public async Task GetImage_GivenNonPdfFile_ReturnsHasImageFalse()
+        {
+            var book = new Book { Path = "TestAssets/dummy.txt" };
+            var result = await _provider.GetImage(book, ImageType.Primary, CancellationToken.None);
+            Assert.False(result.HasImage);
+        }
+
+        [Fact]
+        public async Task GetImage_GivenValidPdfFile_ReturnsImage()
+        {
+            var book = new Book { Path = "TestAssets/dummy.pdf" };
+            var result = await _provider.GetImage(book, ImageType.Primary, CancellationToken.None);
+
+            // Verify logs first to get more information on failure
+            _loggerMock.Verify(
+                x => x.Log(
+                    LogLevel.Information,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v != null && v.ToString()!.Contains("Attempting to create PDF cover for TestAssets/dummy.pdf")),
+                    It.IsAny<Exception?>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
+
+            _loggerMock.Verify(
+                x => x.Log(
+                    LogLevel.Information,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v != null && v.ToString()!.Contains("Successfully created PDF cover for TestAssets/dummy.pdf")),
+                    It.IsAny<Exception?>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
+
+            if (result.HasImage)
+            {
+                Assert.NotNull(result.Stream);
+                Assert.True(result.Stream.Length > 0);
+                Assert.Equal(ImageFormat.Jpg, result.Format);
+                result.Stream.Dispose();
+            }
+
+            // Assert this last, so we can see logger failures first.
+            Assert.True(result.HasImage);
+        }
+
+        [Fact]
+        public async Task GetImage_GivenCorruptPdfFile_ReturnsHasImageFalse()
+        {
+            var book = new Book { Path = "TestAssets/corrupt.pdf" };
+            var result = await _provider.GetImage(book, ImageType.Primary, CancellationToken.None);
+
+            Assert.False(result.HasImage);
+        }
+
+        [Fact]
+        public async Task GetImage_GivenNonExistentFile_ReturnsHasImageFalse()
+        {
+            var book = new Book { Path = "nonexistent.pdf" };
+            var result = await _provider.GetImage(book, ImageType.Primary, CancellationToken.None);
+
+            Assert.False(result.HasImage);
+
+            _loggerMock.Verify(
+                x => x.Log(
+                    LogLevel.Error,
+                    It.IsAny<EventId>(),
+                    It.Is<It.IsAnyType>((v, t) => v != null && v.ToString()!.Contains("Failed to load cover from nonexistent.pdf")),
+                    It.IsAny<Exception?>(),
+                    It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+                Times.Once);
+        }
+    }
+}

--- a/tests/Jellyfin.Plugin.Bookshelf.Tests/PDFCoverProviderTests.cs
+++ b/tests/Jellyfin.Plugin.Bookshelf.Tests/PDFCoverProviderTests.cs
@@ -2,7 +2,7 @@ using System;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using Jellyfin.Plugin.Pdfcover.Providers;
+using Jellyfin.Plugin.Bookshelf.Providers;
 using MediaBrowser.Controller.Entities;
 using MediaBrowser.Controller.Providers;
 using MediaBrowser.Model.Drawing;
@@ -10,7 +10,7 @@ using MediaBrowser.Model.Entities;
 using Microsoft.Extensions.Logging;
 using Moq;
 
-namespace Jellyfin.Plugin.PDFCover.Tests
+namespace Jellyfin.Plugin.Bookshelf.Tests
 {
     public class PDFCoverProviderTests
     {

--- a/tests/Jellyfin.Plugin.Bookshelf.Tests/TestAssets/dummy.pdf
+++ b/tests/Jellyfin.Plugin.Bookshelf.Tests/TestAssets/dummy.pdf
@@ -1,0 +1,21 @@
+%PDF-1.0
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] >>
+endobj
+xref
+0 4
+0000000000 65535 f
+0000000010 00000 n
+0000000058 00000 n
+0000000113 00000 n
+trailer
+<< /Size 4 /Root 1 0 R >>
+startxref
+178
+%%EOF

--- a/tests/Jellyfin.Plugin.Bookshelf.Tests/TestAssets/dummy.txt
+++ b/tests/Jellyfin.Plugin.Bookshelf.Tests/TestAssets/dummy.txt
@@ -1,0 +1,1 @@
+this is not a pdf


### PR DESCRIPTION
This PR introduces a new image fetcher for Books. It enables the extraction of cover images from PDF files.

Closes #134 Also likely addresses #114 as a side effect of how library files are copied.